### PR TITLE
Adds collapsing feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.10",
+    "recompose": "^0.26.0",
     "sanitize.css": "^5.0.0",
     "styled-components": "^2.1.1"
   },

--- a/src/board-grid/board-grid.js
+++ b/src/board-grid/board-grid.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import withState from 'recompose/withState';
+import withProps from 'recompose/withProps';
+import compose from 'recompose/compose';
 import Column from './column';
 
 import ArrowIcon from '../svg-icons/arrow-icon'
@@ -9,13 +12,16 @@ const MemberIssuesContainer = styled.div`
 `;
 
 const ColumnsContainer = styled.div`
-    display: flex;
     align-content: stretch;
+    display: flex;
+    height: ${({isCollapsed}) => (isCollapsed ? 0 : 'auto')};
+    overflow: hidden;
 `;
 
 const MemberInitials = styled.h3`
-    padding: 1rem;
+    cursor: pointer;
     font-size: 1.4rem;
+    padding: 1rem;
 `;
 
 const CountOfIssues = styled.span`
@@ -28,33 +34,38 @@ const CountOfIssues = styled.span`
 
 const ArrowIconContainer = styled.span`
     top: -1.5px;
-    cursor: pointer;
     padding-right: 5px;
     position: relative;
-    
+
     svg {
-        transform: rotate(${({isCollapsed}) => isCollapsed && '90deg'})
+        transform: rotate(${({isCollapsed}) => isCollapsed && '90deg'});
+        transition: transform .2s;
     }
 `;
 
-const BoardGrid = ({columns, initials, onOpenItemDetails}) => {
+const withCollapseToggle = compose(
+    withState('isCollapsed', 'setCollapsed', false),
+    withProps(({isCollapsed, setCollapsed}) => ({ toggle: () => setCollapsed(!isCollapsed)}))
+);
+
+const BoardGrid = ({columns, initials, isCollapsed, onOpenItemDetails, toggle}) => {
     const getCountOfIssues = (columns) => columns.reduce((count, items) => count + items.length, 0);
 
     return (
         <MemberIssuesContainer>
-            <MemberInitials>
-                <ArrowIconContainer isCollapsed={true}>
+            <MemberInitials onClick={toggle}>
+                <ArrowIconContainer isCollapsed={isCollapsed}>
                     <ArrowIcon />
                 </ArrowIconContainer>
                 {initials}
                 <CountOfIssues>{getCountOfIssues(columns)} issues</CountOfIssues>
             </MemberInitials>
 
-            <ColumnsContainer>
+            <ColumnsContainer isCollapsed={isCollapsed}>
                 {columns.map((items, key) => <Column key={key} items={items} onOpenItemDetails={onOpenItemDetails} />)}
             </ColumnsContainer>
         </MemberIssuesContainer>
     )
 };
 
-export default BoardGrid;
+export default withCollapseToggle(BoardGrid);


### PR DESCRIPTION
This is the PR for the issue in #10 
Little change that I would propose to your specification:
I made the whole header interactive, not just the arrow, as pressing only the tiny arrow is quite tedious.

I also added [recompose](https://github.com/acdlite/recompose/), a library for higher order components. This allowed me to add local state (the collapsed state), while keeping a simple stateless functional component for rendering. If you want your state to live in the App file, I can pull it up.